### PR TITLE
Three new queries, and non-precerts in others

### DIFF
--- a/queries/who.impact-other-cas.cas-left-for-le.sql
+++ b/queries/who.impact-other-cas.cas-left-for-le.sql
@@ -36,8 +36,8 @@ WHERE
   AND inner_org_name != 'Let\'s Encrypt'
   AND p443.https.tls.certificate.parsed.subject_dn = certs.parsed.subject_dn
 
-  -- Let's only look at precerts for other CAs.
-  AND certs.precert
+  -- Let's only look at non-precerts.
+  AND not certs.precert
 
   -- Validity of other cert must have started before the validity of the current
   -- Let's Encrypt cert.

--- a/queries/who.impact-other-cas.le-sites-new-to-tls-or-not.sql
+++ b/queries/who.impact-other-cas.le-sites-new-to-tls-or-not.sql
@@ -6,7 +6,7 @@
 -- starting BEFORE the LE certificate was issued?
 
 SELECT
-  COUNT(*) total certs,
+  COUNT(*) total_certs,
   COUNTIF(certs.metadata.seen_in_scan) as seen_in_scan_ct,
   COUNTIF(not certs.metadata.seen_in_scan) as not_seen_in_scan_ct
 FROM
@@ -19,12 +19,11 @@ WHERE
   -- The orgname of the domain certificate is LE.
   org_name = 'Let\'s Encrypt'
 
-  -- Let's only look at precerts.
-  -- TODO: for non-LE certificates, is this still a good metric to see what
-  --       is being provisioned in the wild?
-  AND certs.precert
+  -- Consider certificates that are not precerts in the certificates
+  -- table.
+  AND not certs.precert
 
-  -- Censys says certs are trusted by browser
+  -- Censys says both certs are trusted by browser
   -- (certificates in certificates table previously valid)
   -- (certificates in domains currently valid/browser trusted)
   AND (certs.validation.apple.was_valid
@@ -43,15 +42,12 @@ WHERE
   AND certs.parsed.validity.start < p443.https.tls.certificate.parsed.validity.start
 
 
--- # Latest answer: 23,934 of 1,753,919 domains present in the domains list
--- # are serving an LE cert and previously had another valid non-LE cert.
--- #
--- # not seen in scan: 23,934
--- #     seen in scan: 0
--- #
--- # That means that for 23,934 out of 237,831 total domains in Alexa top million
--- # that give LE certs back, previous CAs were used.
--- #
--- # This shows that the majority actually are new to HTTPS! Because a good
--- # amount of the LE certs in the Alexa top million seem to not have had another
--- # CA before Let's Encrypt.
+# Latest answer: 64,148 of 1,358,098 domains present in the domains list
+# are serving an LE cert and previously had another valid non-LE cert.
+#
+# That means that 64,148 out of 241,802 total domains in Alexa top million
+# that give LE certs back, previous CAs were used.
+#
+# This shows that the majority actually are new to HTTPS! Because a good
+# amount of the LE certs in the Alexa top million seem to not have had another
+# CA before Let's Encrypt.

--- a/queries/who.impact-other-cas.valid-cas-with-le-in-past.sql
+++ b/queries/who.impact-other-cas.valid-cas-with-le-in-past.sql
@@ -1,0 +1,26 @@
+-- Which sites in the Alexa top million are currently a cert
+-- that 1) is not an LE certificate and 2) the sites has had a valid LE certificate in
+-- the past?
+
+SELECT
+  COUNT(*) total_certs, AVG(alexa_rank), MIN(alexa_rank), MAX(alexa_rank)
+FROM
+  `censys-io.domain_public.current`,
+  UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name,
+  (
+  SELECT
+    certs.parsed.subject_dn as subject_dn,
+    MIN(certs.parsed.validity.start) as min_validity
+  FROM
+    `censys-io.certificates_public.certificates` AS certs,
+    UNNEST(parsed.issuer.organization) AS inner_org_name
+  WHERE
+    inner_org_name = 'Let\'s Encrypt'
+    AND NOT certs.precert
+  GROUP BY
+    certs.parsed.subject_dn ) AS min_le_validity_times
+WHERE
+  org_name != 'Let\'s Encrypt'
+  AND min_le_validity_times.subject_dn = p443.https.tls.certificate.parsed.subject_dn
+  AND p443.https.tls.validation.browser_trusted
+  AND min_le_validity_times.min_validity < p443.https.tls.certificate.parsed.validity.start

--- a/queries/who.popularity.alexa-top-mill-over-time.sql
+++ b/queries/who.popularity.alexa-top-mill-over-time.sql
@@ -1,0 +1,237 @@
+-- How has the popularity of Let's Encrypt domains changed
+-- amongst the Alexa top million sites since its release?
+
+-- NOTE: Censys keeps data for a single scan for a week after some time
+--       has passed, so this query samples the data Censys has available
+--       each month since Let's Encrypt was released.
+
+SELECT
+  *
+FROM (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_12
+  FROM
+    `censys-io.domain_public.20181201`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_11
+  FROM
+    `censys-io.domain_public.20181101`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_10
+  FROM
+    `censys-io.domain_public.20181001`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_9
+  FROM
+    `censys-io.domain_public.20180901`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_8
+  FROM
+    `censys-io.domain_public.20180801`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_7
+  FROM
+    `censys-io.domain_public.20180701`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_6
+  FROM
+    `censys-io.domain_public.20180601`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_5
+  FROM
+    `censys-io.domain_public.20180501`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_4
+  FROM
+    `censys-io.domain_public.20180403`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_3
+  FROM
+    `censys-io.domain_public.20180306`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_2
+  FROM
+    `censys-io.domain_public.20180207`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_18_1
+  FROM
+    `censys-io.domain_public.20180102`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_12
+  FROM
+    `censys-io.domain_public.20171205`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_11
+  FROM
+    `censys-io.domain_public.20171107`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_10
+  FROM
+    `censys-io.domain_public.20171003`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_9
+  FROM
+    `censys-io.domain_public.20170905`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_8
+  FROM
+    `censys-io.domain_public.20170801`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_7
+  FROM
+    `censys-io.domain_public.20170704`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_6
+  FROM
+    `censys-io.domain_public.20170606`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_5
+  FROM
+    `censys-io.domain_public.20170502`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_4
+  FROM
+    `censys-io.domain_public.20170404`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_3
+  FROM
+    `censys-io.domain_public.20170314`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_2
+  FROM
+    `censys-io.domain_public.20170207`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_17_1
+  FROM
+    `censys-io.domain_public.20170103`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_12
+  FROM
+    `censys-io.domain_public.20161209`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_11
+  FROM
+    `censys-io.domain_public.20161108`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_10
+  FROM
+    `censys-io.domain_public.20161017`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_9
+  FROM
+    `censys-io.domain_public.20160902`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_8
+  FROM
+    `censys-io.domain_public.20160806`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_7
+  FROM
+    `censys-io.domain_public.20160705`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_6
+  FROM
+    `censys-io.domain_public.20160608`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_5
+  FROM
+    `censys-io.domain_public.20160502`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_4
+  FROM
+    `censys-io.domain_public.20160404`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_3
+  FROM
+    `censys-io.domain_public.20160307`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_2
+  FROM
+    `censys-io.domain_public.20160204`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_16_1
+  FROM
+    `censys-io.domain_public.20160107`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_15_12
+  FROM
+    `censys-io.domain_public.20151203`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name),
+  (
+  SELECT
+    COUNTIF(org_name = "Let\'s Encrypt") / 1000000 * 100 AS percent_lets_encrypt_15_11
+  FROM
+    `censys-io.domain_public.20151126`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name)

--- a/queries/who.popularity.in-alexa-top-mill-vs-not.sql
+++ b/queries/who.popularity.in-alexa-top-mill-vs-not.sql
@@ -1,0 +1,29 @@
+-- Question: What percentage of all currently valid Let's Encrypt
+-- cer
+
+SELECT
+  total_valid_now,
+  valid_alexa_top_mill,
+  valid_alexa_top_mill / total_valid_now * 100 AS percentage
+FROM (
+  SELECT
+    COUNT(*) AS valid_alexa_top_mill
+  FROM
+    `censys-io.domain_public.current`,
+    UNNEST(p443.https.tls.certificate.parsed.issuer.organization) AS org_name
+  WHERE
+    org_name = "Let\'s Encrypt"
+    AND p443.https.tls.validation.browser_trusted ),
+  (
+  SELECT
+    COUNT(*) AS total_valid_now
+  FROM
+    `censys-io.certificates_public.certificates` AS certs,
+    UNNEST(parsed.issuer.organization) AS org_name
+  WHERE
+    org_name = 'Let\'s Encrypt'
+    AND NOT certs.precert
+    AND (certs.validation.apple.valid
+      OR certs.validation.microsoft.valid
+      OR certs.validation.google_ct_primary.valid
+      OR certs.validation.nss.valid))


### PR DESCRIPTION
1) Which sites in the Alexa top million are currently a cert that 1) is not an LE certificate and 2) the sites has had a valid LE certificate in the past?
2) How has the popularity of Let's Encrypt domains changed amongst the Alexa top million sites since its release?
3) What percentage of all valid LE certs right now are being served by sites in the Alexa top million?